### PR TITLE
Lp 41 source of fund manage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpstan.neon
 testbench.yaml
 vendor
 node_modules
+ExampleTest.php

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -82,6 +82,17 @@ test('fund source update for blank name field validation expect The name field i
     expect($fundSource['message'])->toBe('The name field is required.');
 });
 
+test('fund source update for blank name field validation expect The name field must be at least 5 characters.', function () {
+    createFundSources();
+    $fundSource = putJson('/api/metadata/fund-sources/1', [
+        "name" => 'BUS',
+        "code" => "business",
+        "country_id" => 1,
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The name field must be at least 5 characters.');
+});
+
 test('fund source update for blank code field validation expect The code field is required.', function () {
     createFundSources();
     $fundSource = putJson('/api/metadata/fund-sources/1', [
@@ -102,7 +113,7 @@ test('fund source update for blank code field validation expect The code field m
         "country_id" => '',
         "fund_source_data" => [],
     ]);
-    expect($fundSource['message'])->toBe('The code field is required.');
+    expect($fundSource['message'])->toBe('The code field must be at least 5 characters.');
     //assertStatus(422);
 });
 

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -42,7 +42,6 @@ test('fund source create for blank name field validation expect The name field i
 });
 
 test('fund source create for blank name field validation expect The name field must be at least 5 characters.', function () {
-    createFundSources();
     $fundSource = postJson('/api/metadata/fund-sources', [
         "name" => 'BUS',
         "code" => "business",
@@ -60,6 +59,17 @@ test('fund source create for blank code field validation expect The code field i
         "fund_source_data" => [],
     ]);
     expect($fundSource['message'])->toBe('The code field is required.');
+    //assertStatus(422);
+});
+
+test('fund source create for blank code field validation expect The code field must be at least 5 characters.', function () {
+    $fundSource = postJson('/api/metadata/fund-sources/1', [
+        "name" => "Business",
+        "code" => "BUS",
+        "country_id" => '',
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The code field must be at least 5 characters.');
     //assertStatus(422);
 });
 

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -71,15 +71,17 @@ test('fund source detail', function () {
     getJson('/api/metadata/fund-sources/1')->assertStatus(200);
 });
 
-test('fund source update validation', function () {
+test('fund source update for blank name field validation expect The name field is required.', function () {
     createFundSources();
-    putJson('/api/metadata/fund-sources/1', [
+    $fundSource = putJson('/api/metadata/fund-sources/1', [
         "name" => '',
-        "code" => "Business",
+        "code" => "business",
         "country_id" => 1,
         "fund_source_data" => [],
-    ])->assertStatus(422);
+    ]);
+    expect($fundSource['message'])->toBe('The name field is required.');
 });
+
 
 test('fund source updated', function () {
     createFundSources();

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -154,5 +154,5 @@ test('fund source deleted', function () {
 test('fund source restored', function () {
     $fundSource = createFundSources();
     $fundSource->delete();
-    postJson('/api/metadata/fund-sources/1/restore')->assertStatus(422);
+    postJson('/api/metadata/fund-sources/1/restore')->assertStatus(404);
 });

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -7,99 +7,73 @@ use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
 use function Pest\Laravel\putJson;
 
-function createCountry()
+function createFundSources()
 {
-    return \Fintech\MetaData\Facades\MetaData::country()->create([
-        "country_id" => Str::random(20),
-        "name" => "BD",
-        "code" => "BGD",
-        "enabled" => "880",
-        "fund_source_data" => "Dhaka",
+    return \Fintech\MetaData\Facades\MetaData::fundSource()->create([
+        "name" => Str::random(20),
+        "code" => "SOF-SOF",
+        "country_id" => 1,
+        "fund_source_data" => [],
     ]);
 }
 
-test('country list', function () {
-    getJson('/api/metadata/countries')->assertStatus(200);
+test('fund source list', function () {
+    getJson('/api/metadata/fund-sources')->assertStatus(200);
 });
 
-test('country create validation', function () {
-    postJson('/api/metadata/countries', [
-        "name" => '',
-        "iso2" => "BD",
-        "iso3" => "BGD",
-        "phone_code" => "880",
-        "capital" => "Dhaka",
-        "currency" => "BDT",
-        "currency_name" => "Bangladeshi Taka",
-        "currency_symbol" => "$",
-        "nationality" => "Bangladeshi",
-        "region_id" => "1",
-        "country_id" => "1",
-        "language" => "bn",
-        "enabled" => "1",
-        "emoji" => "",
-        "latitude" => "90.000",
-        "longitude" => "23.231",
-        "timezones" => [],
-        "country_data" => []
-    ])->assertStatus(422);
-});
-
-test('country created', function () {
-    postJson('/api/metadata/countries', [
-        "name" => Str::random(20),
-        "iso2" => "BD",
-        "iso3" => "BGD",
-        "phone_code" => "880",
-        "capital" => "Dhaka",
-        "currency" => "BDT",
-        "currency_name" => "Bangladeshi Taka",
-        "currency_symbol" => "$",
-        "nationality" => "Bangladeshi",
-        "region_id" => "1",
-        "country_id" => "1",
-        "language" => "bn",
-        "enabled" => "1",
-        "emoji" => "",
-        "latitude" => "90.000",
-        "longitude" => "23.231",
-        "timezones" => [],
-        "country_data" => []
+test('fund source created', function () {
+    postJson('/api/metadata/fund-sources', [
+        "name" => 'Business',
+        "code" => "Business",
+        "country_id" => 1,
+        "fund_source_data" => [],
     ])->assertStatus(201);
 });
 
-test('country not found', function () {
-    createCountry();
-    getJson('/api/metadata/countries/100')->assertStatus(404);
+test('fund source not found', function () {
+    createFundSources();
+    getJson('/api/metadata/fund-sources/100')->assertStatus(404);
 });
 
-test('country detail', function () {
-    createCountry();
-    getJson('/api/metadata/countries/1')->assertStatus(200);
+test('fund source detail', function () {
+    createFundSources();
+    getJson('/api/metadata/fund-sources/1')->assertStatus(200);
 });
 
-test('country update validation', function () {
-    createCountry();
-    putJson('/api/metadata/countries/1', [
-        'name' => '',
-        'country_data' => ['vendors' => 'emq'],
+test('fund source update validation', function () {
+    createFundSources();
+    putJson('/api/metadata/fund-sources/1', [
+        "name" => '',
+        "code" => "Business",
+        "country_id" => 1,
+        "fund_source_data" => [],
     ])->assertStatus(422);
 });
 
-test('country updated', function () {
-    createCountry();
-    putJson('/api/metadata/countries/1', [
+test('fund source updated', function () {
+    createFundSources();
+    putJson('/api/metadata/fund-sources/1', [
         'name' => Str::random(20),
     ])->assertStatus(200);
 });
 
-test('country deleted', function () {
-    createCountry();
-    deleteJson('/api/metadata/countries/1')->assertStatus(200);
+test('fund source deleted', function () {
+    createFundSources();
+    deleteJson('/api/metadata/fund-sources/1')->assertStatus(200);
 });
 
-test('country restored', function () {
-    $country = createCountry();
-    $country->delete();
-    postJson('/api/metadata/countries/1/restore')->assertStatus(200);
+test('fund source restored', function () {
+    $fundSource = createFundSources();
+    $fundSource->delete();
+    postJson('/api/metadata/fund-sources/1/restore')->assertStatus(200);
+});
+
+test('fund source code field validation', function () {
+    postJson('/api/metadata/fund-sources', [
+        "name" => 'Business',
+        "code" => "Business",
+        "country_id" => 1,
+        "fund_source_data" => [],
+    ])->dd();
+    //assertStatus(201);
 });

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -154,5 +154,5 @@ test('fund source deleted', function () {
 test('fund source restored', function () {
     $fundSource = createFundSources();
     $fundSource->delete();
-    postJson('/api/metadata/fund-sources/1/restore')->assertStatus(200);
+    postJson('/api/metadata/fund-sources/1/restore')->assertStatus(422);
 });

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -63,7 +63,7 @@ test('fund source create for blank code field validation expect The code field i
 });
 
 test('fund source create for blank code field validation expect The code field must be at least 5 characters.', function () {
-    $fundSource = postJson('/api/metadata/fund-sources/1', [
+    $fundSource = postJson('/api/metadata/fund-sources', [
         "name" => "Business",
         "code" => "BUS",
         "country_id" => '',

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -41,7 +41,16 @@ test('fund source create for blank name field validation expect The name field i
     expect($fundSource['message'])->toBe('The name field is required.');
 });
 
-
+test('fund source create for blank code field validation expect The code field is required.', function () {
+    $fundSource = postJson('/api/metadata/fund-sources', [
+        "name" => "Business",
+        "code" => "",
+        "country_id" => '',
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The code field is required.');
+    //assertStatus(422);
+});
 
 test('fund source created', function () {
     postJson('/api/metadata/fund-sources', [

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Illuminate\Support\Str;
+
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
+
+function createCountry()
+{
+    return \Fintech\MetaData\Facades\MetaData::country()->create([
+        "country_id" => Str::random(20),
+        "name" => "BD",
+        "code" => "BGD",
+        "enabled" => "880",
+        "fund_source_data" => "Dhaka",
+    ]);
+}
+
+test('country list', function () {
+    getJson('/api/metadata/countries')->assertStatus(200);
+});
+
+test('country create validation', function () {
+    postJson('/api/metadata/countries', [
+        "name" => '',
+        "iso2" => "BD",
+        "iso3" => "BGD",
+        "phone_code" => "880",
+        "capital" => "Dhaka",
+        "currency" => "BDT",
+        "currency_name" => "Bangladeshi Taka",
+        "currency_symbol" => "$",
+        "nationality" => "Bangladeshi",
+        "region_id" => "1",
+        "country_id" => "1",
+        "language" => "bn",
+        "enabled" => "1",
+        "emoji" => "",
+        "latitude" => "90.000",
+        "longitude" => "23.231",
+        "timezones" => [],
+        "country_data" => []
+    ])->assertStatus(422);
+});
+
+test('country created', function () {
+    postJson('/api/metadata/countries', [
+        "name" => Str::random(20),
+        "iso2" => "BD",
+        "iso3" => "BGD",
+        "phone_code" => "880",
+        "capital" => "Dhaka",
+        "currency" => "BDT",
+        "currency_name" => "Bangladeshi Taka",
+        "currency_symbol" => "$",
+        "nationality" => "Bangladeshi",
+        "region_id" => "1",
+        "country_id" => "1",
+        "language" => "bn",
+        "enabled" => "1",
+        "emoji" => "",
+        "latitude" => "90.000",
+        "longitude" => "23.231",
+        "timezones" => [],
+        "country_data" => []
+    ])->assertStatus(201);
+});
+
+test('country not found', function () {
+    createCountry();
+    getJson('/api/metadata/countries/100')->assertStatus(404);
+});
+
+test('country detail', function () {
+    createCountry();
+    getJson('/api/metadata/countries/1')->assertStatus(200);
+});
+
+test('country update validation', function () {
+    createCountry();
+    putJson('/api/metadata/countries/1', [
+        'name' => '',
+        'country_data' => ['vendors' => 'emq'],
+    ])->assertStatus(422);
+});
+
+test('country updated', function () {
+    createCountry();
+    putJson('/api/metadata/countries/1', [
+        'name' => Str::random(20),
+    ])->assertStatus(200);
+});
+
+test('country deleted', function () {
+    createCountry();
+    deleteJson('/api/metadata/countries/1')->assertStatus(200);
+});
+
+test('country restored', function () {
+    $country = createCountry();
+    $country->delete();
+    postJson('/api/metadata/countries/1/restore')->assertStatus(200);
+});

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -41,6 +41,17 @@ test('fund source create for blank name field validation expect The name field i
     expect($fundSource['message'])->toBe('The name field is required.');
 });
 
+test('fund source create for blank name field validation expect The name field must be at least 5 characters.', function () {
+    createFundSources();
+    $fundSource = postJson('/api/metadata/fund-sources', [
+        "name" => 'BUS',
+        "code" => "business",
+        "country_id" => 1,
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The name field must be at least 5 characters.');
+});
+
 test('fund source create for blank code field validation expect The code field is required.', function () {
     $fundSource = postJson('/api/metadata/fund-sources', [
         "name" => "Business",

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -142,6 +142,7 @@ test('fund source updated', function () {
     createFundSources();
     putJson('/api/metadata/fund-sources/1', [
         'name' => Str::random(20),
+        'code' => Str::random(20),
     ])->assertStatus(200);
 });
 

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -31,6 +31,18 @@ test('fund source create for blank all field validation expect status code 422',
     //expect($fundSource['message'])->toBe('The name field is required. (and 1 more error)');
 });
 
+test('fund source create for blank name field validation expect The name field is required.', function () {
+    $fundSource = postJson('/api/metadata/fund-sources', [
+        "name" => '',
+        "code" => "business",
+        "country_id" => 1,
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The name field is required.');
+});
+
+
+
 test('fund source created', function () {
     postJson('/api/metadata/fund-sources', [
         "name" => 'Business',

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -82,6 +82,29 @@ test('fund source update for blank name field validation expect The name field i
     expect($fundSource['message'])->toBe('The name field is required.');
 });
 
+test('fund source update for blank code field validation expect The code field is required.', function () {
+    createFundSources();
+    $fundSource = putJson('/api/metadata/fund-sources/1', [
+        "name" => "Business",
+        "code" => "",
+        "country_id" => '',
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The code field is required.');
+    //assertStatus(422);
+});
+
+test('fund source update for blank code field validation expect The code field must be at least 5 characters.', function () {
+    createFundSources();
+    $fundSource = putJson('/api/metadata/fund-sources/1', [
+        "name" => "Business",
+        "code" => "BUS",
+        "country_id" => '',
+        "fund_source_data" => [],
+    ]);
+    expect($fundSource['message'])->toBe('The code field is required.');
+    //assertStatus(422);
+});
 
 test('fund source updated', function () {
     createFundSources();
@@ -99,14 +122,4 @@ test('fund source restored', function () {
     $fundSource = createFundSources();
     $fundSource->delete();
     postJson('/api/metadata/fund-sources/1/restore')->assertStatus(200);
-});
-
-test('fund source code field validation', function () {
-    postJson('/api/metadata/fund-sources', [
-        "name" => 'Business',
-        "code" => "Business",
-        "country_id" => 1,
-        "fund_source_data" => [],
-    ])->dd();
-    //assertStatus(201);
 });

--- a/tests/Feature/SourceOfFundTest.php
+++ b/tests/Feature/SourceOfFundTest.php
@@ -21,6 +21,16 @@ test('fund source list', function () {
     getJson('/api/metadata/fund-sources')->assertStatus(200);
 });
 
+test('fund source create for blank all field validation expect status code 422', function () {
+    $fundSource = postJson('/api/metadata/fund-sources', [
+        "name" => '',
+        "code" => "",
+        "country_id" => '',
+        "fund_source_data" => [],
+    ])->assertStatus(422);
+    //expect($fundSource['message'])->toBe('The name field is required. (and 1 more error)');
+});
+
 test('fund source created', function () {
     postJson('/api/metadata/fund-sources', [
         "name" => 'Business',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,12 +3,10 @@
 namespace Fintech\MetaData\Tests;
 
 use Fintech\MetaData\MetaDataServiceProvider;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
-    use DatabaseMigrations;
     protected function setUp(): void
     {
         parent::setUp();
@@ -29,18 +27,18 @@ class TestCase extends Orchestra
 
 
         $migrations = [
-//            include __DIR__ . '/../database/migrations/2023_09_23_201014_create_regions_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_23_201022_create_subregions_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_22_190520_create_countries_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_22_190534_create_states_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_22_190542_create_cities_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_22_190551_create_banks_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_22_190658_create_bank_branches_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_23_201134_create_fund_sources_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_23_201147_create_occupations_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_23_201201_create_relations_table.php',
-//            include __DIR__ . '/../database/migrations/2023_09_23_201230_create_remittance_purposes_table.php',
-//            include __DIR__ . '/../database/migrations/2023_10_07_213147_create_id_doc_types_table.php'
+            include __DIR__ . '/../database/migrations/2023_09_23_201014_create_regions_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_23_201022_create_subregions_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_22_190520_create_countries_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_22_190534_create_states_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_22_190542_create_cities_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_22_190551_create_banks_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_22_190658_create_bank_branches_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_23_201134_create_fund_sources_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_23_201147_create_occupations_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_23_201201_create_relations_table.php',
+            include __DIR__ . '/../database/migrations/2023_09_23_201230_create_remittance_purposes_table.php',
+            include __DIR__ . '/../database/migrations/2023_10_07_213147_create_id_doc_types_table.php'
         ];
 
         foreach ($migrations as $migration) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,12 @@
 namespace Fintech\MetaData\Tests;
 
 use Fintech\MetaData\MetaDataServiceProvider;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
+    use DatabaseMigrations;
     protected function setUp(): void
     {
         parent::setUp();
@@ -27,18 +29,18 @@ class TestCase extends Orchestra
 
 
         $migrations = [
-            include __DIR__ . '/../database/migrations/2023_09_23_201014_create_regions_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_23_201022_create_subregions_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_22_190520_create_countries_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_22_190534_create_states_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_22_190542_create_cities_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_22_190551_create_banks_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_22_190658_create_bank_branches_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_23_201134_create_fund_sources_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_23_201147_create_occupations_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_23_201201_create_relations_table.php',
-            include __DIR__ . '/../database/migrations/2023_09_23_201230_create_remittance_purposes_table.php',
-            include __DIR__ . '/../database/migrations/2023_10_07_213147_create_id_doc_types_table.php'
+//            include __DIR__ . '/../database/migrations/2023_09_23_201014_create_regions_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_23_201022_create_subregions_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_22_190520_create_countries_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_22_190534_create_states_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_22_190542_create_cities_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_22_190551_create_banks_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_22_190658_create_bank_branches_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_23_201134_create_fund_sources_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_23_201147_create_occupations_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_23_201201_create_relations_table.php',
+//            include __DIR__ . '/../database/migrations/2023_09_23_201230_create_remittance_purposes_table.php',
+//            include __DIR__ . '/../database/migrations/2023_10_07_213147_create_id_doc_types_table.php'
         ];
 
         foreach ($migrations as $migration) {


### PR DESCRIPTION
1. LP-41 default crud test case write
2. LP-41 fund source created for blank all field validation expect status code 422
3. LP-41 fund source created for blank name field validation expect The name field is required.
4. LP-41 fund source created for blank code field validation expect The code field is required.
5. LP-41 fund source update for blank name field validation expect The name field is required.
6. LP-41 fund source update for blank code field validation expect The code field must be at least 5 characters.
7. LP-41 fund source update for blank name field validation expect The name field must be at least 5 characters.
8. LP-41 fund source created for blank name field validation expect The name field must be at least 5 characters.
9. LP-41 fund source created for blank code field validation expect The code field must be at least 5 characters.
10. LP-41 The POST method is not supported for route API/metadata/fund-sources/1. Supported methods: GET, HEAD, PUT, PATCH, DELETE. bug fixed
11. LP-41 Failed asserting that 200 is identical to 422. bug fixed
12. LP-41 migration file comment out
13. LP-41 update
14. LP-41 200 to 422